### PR TITLE
OZ-348: Update SENAITE_SERVER_URL to use internal Docker network URL for SENAITE service.

### DIFF
--- a/docker-compose-senaite.yml
+++ b/docker-compose-senaite.yml
@@ -38,7 +38,7 @@ services:
         condition: service_started
     env_file: eip.env
     environment:
-      - SENAITE_SERVER_URL=https://${SENAITE_HOSTNAME}/senaite
+      - SENAITE_SERVER_URL=http://senaite:8080/senaite
       - SENAITE_SERVER_USER=${SENAITE_ADMIN_USER}
       - SENAITE_SERVER_PASSWORD=${SENAITE_ADMIN_PASSWORD}
       - OPENMRS_SERVER_URL=http://openmrs:8080/openmrs


### PR DESCRIPTION
This PR changes the `SENAITE_SERVER_URL` from using the `SENAITE_HOSTNAME` environment variable to a hardcoded internal Docker network URL. This is to ensure that the `eip-openmrs-senaite` service can always reach the senaite service within the Docker network. Already `eip-odoo-openmrs` uses internal docker network URLs. see [here](https://github.com/ozone-his/ozone-docker-compose/blob/main/docker-compose-odoo.yml#L85-L86)