### PR TITLE
OZ-461: Upgrade Ozone Docker MariaDB to `v10.8`

### DIFF
--- a/docker-compose-common.yml
+++ b/docker-compose-common.yml
@@ -19,7 +19,7 @@ services:
       MYSQL_ROOT_PASSWORD: "${MYSQL_ROOT_PASSWORD}"
     healthcheck:
       test: "exit 0"
-    image: mariadb:10.2
+    image: mariadb:10.8
     networks:
       - ozone
     ports:


### PR DESCRIPTION
Issue: https://mekomsolutions.atlassian.net/jira/software/c/projects/OZ/issues/OZ-461

I've tested this and works well with the latest changes after the upgrade of EIP stack.