### PR TITLE
OZ-196: Fix `superset-worker` celery worker command

### DIFF
--- a/docker-compose-superset.yml
+++ b/docker-compose-superset.yml
@@ -44,6 +44,8 @@ services:
     networks:
       - ozone
     restart: unless-stopped
+    volumes:
+      - ${SUPERSET_CONFIG_PATH}/:/etc/superset/
     
     
   superset-init:

--- a/docker-compose-superset.yml
+++ b/docker-compose-superset.yml
@@ -31,7 +31,7 @@ services:
       - ${SUPERSET_CONFIG_PATH}/:/etc/superset/
     
   superset-worker:
-    command: "celery worker --app=superset.tasks.celery_app:app"
+    command: "celery --app=superset.tasks.celery_app:app worker --pool=gevent -Ofair -n worker1@%h --loglevel=INFO"
     depends_on:
       redis:
         condition: service_started


### PR DESCRIPTION
This PR fixes the `superset-worker` docker-compose service which currently fails with the error:

```log
Error: No such option: --app
2024-02-14 15:56:54 You are using `--app` as an option of the worker sub-command:
2024-02-14 15:56:54 celery worker --app celeryapp <...>
2024-02-14 15:56:54 
2024-02-14 15:56:54 The support for this usage was removed in Celery 5.0. Instead you should use `--app` as a global option:
2024-02-14 15:56:54 celery --app celeryapp worker <...>
2024-02-14 15:56:54 Usage: celery worker [OPTIONS]
2024-02-14 15:56:54 Try 'celery worker --help' for help.
```