### PR TITLE
OZ-348: EIP Demo service doesn't require `eip.env` file

### DIFF
--- a/.env
+++ b/.env
@@ -108,14 +108,10 @@ EMR_WEIGHT_CONCEPT=
 ODOO_ENABLE_EXTRA_CUSTOMER_FIELDS_ROUTE=false
 ODOO_ENABLE_EXTRA_QUOTATION_FIELDS_ROUTE=false
 
+#
 # EIP client Demo
-# TODO: Move this into its own env file. Attention, doing this will still
-# require to provide the .env and eip.env files to the service.
 #
 NUMBER_OF_DEMO_PATIENTS=
-EIP_DB_NAME_DEMO=openmrs_eip_mgt
-EIP_DB_USER_DEMO=openmrs_eip_mgt
-EIP_DB_PASSWORD_DEMO=password
 
 #
 # Mounts

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -3,11 +3,12 @@ services:
   eip-demo:
     image: mekomsolutions/eip-client
     restart: "no"
-    env_file: ../eip.env
     environment:
       - NUMBER_OF_DEMO_PATIENTS=${NUMBER_OF_DEMO_PATIENTS}
       - EIP_PROFILE=prod
       - OPENMRS_URL=http://openmrs:8080/openmrs
+      - OPENMRS_USER=${OPENMRS_USER}
+      - OPENMRS_PASSWORD=${OPENMRS_PASSWORD}
     volumes:
       - "./eip/config:/eip-client/config"
       - "./eip/routes:/eip-client/routes"


### PR DESCRIPTION
This PR simplifies EIP Demo service configurations.