### PR TITLE
OZ-464: Remove `docker-compose-erpnext.yml` from `docker-compose-files.txt`.

### DIFF
--- a/scripts/docker-compose-files.txt
+++ b/scripts/docker-compose-files.txt
@@ -3,4 +3,3 @@ docker-compose-odoo.yml
 docker-compose-openmrs.yml
 docker-compose-senaite.yml
 docker-compose-superset.yml
-docker-compose-erpnext.yml


### PR DESCRIPTION
This PR Removes `docker-compose-erpnext.yml` from `docker-compose-files.txt`.