### PR TITLE
OZ-464: Change ERPNext service port to 8080 & listen to Encounter resource events.

### DIFF
--- a/.env
+++ b/.env
@@ -59,7 +59,7 @@ ODOO_DATABASE=odoo
 #
 # ERPNext
 #
-ERPNEXT_USER=Administrator
+ERPNEXT_USER=administrator
 ERPNEXT_PASSWORD=password
 ERPNEXT_DB_NAME=erpnext
 

--- a/docker-compose-erpnext.yml
+++ b/docker-compose-erpnext.yml
@@ -210,7 +210,7 @@ services:
       erpnext:
         condition: service_started
     environment:
-      - ERPNEXT_SERVER_URL=http://erpnext:8082/api
+      - ERPNEXT_SERVER_URL=http://erpnext:8080/api
       - ERPNEXT_USERNAME=${ERPNEXT_USER}
       - ERPNEXT_PASSWORD=${ERPNEXT_PASSWORD}
       - ERPNEXT_OPENMRS_ENABLE_PATIENT_SYNC=false
@@ -225,7 +225,7 @@ services:
       - OPENMRS_DB_NAME=${OPENMRS_DB_NAME}
       - OPENMRS_DB_USER=${OPENMRS_DB_USER}
       - OPENMRS_DB_PASSWORD=${OPENMRS_DB_PASSWORD}
-      - EIP_FHIR_RESOURCES=Patient,ServiceRequest,MedicationRequest
+      - EIP_FHIR_RESOURCES=Patient,ServiceRequest,MedicationRequest,Encounter
       - EIP_FHIR_SERVER_URL=http://openmrs:8080/openmrs/ws/fhir2/R4
       - EIP_FHIR_USERNAME=${OPENMRS_USER}
       - EIP_FHIR_PASSWORD=${OPENMRS_PASSWORD}


### PR DESCRIPTION
ERPNext uses an internal Nginx(within the [frappe_docker](https://github.com/frappe/frappe_docker/blob/1c78d3eb6a0d4f8c5c929baf989d60cb0e190fa1/resources/nginx-template.conf#L10) docker project) which listens at port 8080.