### PR TITLE
OZ-464: Remove Docker compose `version` since it's obsolete.

### DIFF
--- a/docker-compose-common.yml
+++ b/docker-compose-common.yml
@@ -59,8 +59,6 @@ services:
       - "${POSTGRES_DATADIR:-postgresql-data}:/var/lib/postgresql/data"
       - "${SQL_SCRIPTS_PATH}/postgresql/create_db.sh:/docker-entrypoint-initdb.d/create_db.sh"
 
-version: "3.7"
-
 volumes:
   mysql-data: ~
   postgresql-data: ~

--- a/docker-compose-erpnext.yml
+++ b/docker-compose-erpnext.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 x-erpnext-image: &erpnext-image
   image: frappe/erpnext:v15.12.2
   platform: linux/amd64


### PR DESCRIPTION
Logs:

```log
WARN[0000] /users/evil-x/ozone/ozone-pro/target/ozonepro-1.0.0-SNAPSHOT/run/docker/docker-compose-common.yml: `version` is obsolete
WARN[0000] /users/evil-x/ozone/ozone-pro/target/ozonepro-1.0.0-SNAPSHOT/run/docker/docker-compose-erpnext.yml: `version` is obsolete
```