### PR TITLE
OZ-476: Add shutdownHandler step in generate-demo-data-route.

### DIFF
--- a/demo/eip/routes/generate-demo-data-route.xml
+++ b/demo/eip/routes/generate-demo-data-route.xml
@@ -24,9 +24,9 @@
 
         <toD cacheSize="-1" uri="{{openmrs.baseUrl}}/ws/rest/v1/referencedemodata/generate"/>
 
-        <!-- On successful completion, run the shutdown server -->
+        <!-- On successful completion, run the shutdown method -->
         <onCompletion>
-            <bean ref="shutdownServer" method="shutdown"/>
+            <bean ref="shutdownHandler" method="shutdown"/>
         </onCompletion>
     </route>
 </routes>

--- a/demo/eip/routes/generate-demo-data-route.xml
+++ b/demo/eip/routes/generate-demo-data-route.xml
@@ -23,5 +23,10 @@
         </setBody>
 
         <toD cacheSize="-1" uri="{{openmrs.baseUrl}}/ws/rest/v1/referencedemodata/generate"/>
+
+        <!-- On successful completion, run the shutdown server -->
+        <onCompletion>
+            <bean ref="shutdownServer" method="shutdown"/>
+        </onCompletion>
     </route>
 </routes>


### PR DESCRIPTION
Added ShutdownServer bean which will be triggered from generate-demo-data-route after the data is generated. It will shutdown the server gracefully.

eip-client https://github.com/ozone-his/eip-client/pull/33 

ozone-docker-compose https://github.com/ozone-his/ozone-docker-compose/pull/96