### PR TITLE
OZ-627: Add dynamic project name suffix for Ozone in Docker Compose

### DIFF
--- a/scripts/destroy-demo.sh
+++ b/scripts/destroy-demo.sh
@@ -15,11 +15,11 @@ INSTALLED_DOCKER_VERSION=$(docker version -f "{{.Server.Version}}")
 MINIMUM_REQUIRED_DOCKER_VERSION_REGEX="^((([2-9][1-9]|[3-9][0]|[0-9]{3,}).*)|(20\.([0-9]{3,}|[1-9][1-9]|[2-9][0]).*)|(20\.10\.([0-9]{3,}|[2-9][0-9]|[1][3-9])))"
 if [[ $INSTALLED_DOCKER_VERSION =~ $MINIMUM_REQUIRED_DOCKER_VERSION_REGEX ]]; then
     echo "$INFO Destroying demo service..."
-    docker compose -p ozone $dockerComposeDemoCLIOptions down -v
+    docker compose -p $PROJECT_NAME $dockerComposeDemoCLIOptions down -v
     echo "$INFO Destroying proxy service..."
-    docker compose -p ozone $dockerComposeProxyCLIOptions down -v
+    docker compose -p $PROJECT_NAME $dockerComposeProxyCLIOptions down -v
     echo "$INFO Destroying Ozone services..."
-    docker compose -p ozone $dockerComposeOzoneCLIOptions down -v  --remove-orphans
+    docker compose -p $PROJECT_NAME $dockerComposeOzoneCLIOptions down -v  --remove-orphans
 else
     echo "$ERROR Docker versions < 20.10.13 are not supported"
 fi

--- a/scripts/destroy-demo.sh
+++ b/scripts/destroy-demo.sh
@@ -11,6 +11,11 @@ setupDirs
 # Export more environment variables
 exportPaths
 
+# Read PROJECT_NAME from the temporary file
+PROJECT_NAME=$(cat /tmp/project_name.txt)
+
+echo "$INFO Destroying $PROJECT_NAME project..."
+
 INSTALLED_DOCKER_VERSION=$(docker version -f "{{.Server.Version}}")
 MINIMUM_REQUIRED_DOCKER_VERSION_REGEX="^((([2-9][1-9]|[3-9][0]|[0-9]{3,}).*)|(20\.([0-9]{3,}|[1-9][1-9]|[2-9][0]).*)|(20\.10\.([0-9]{3,}|[2-9][0-9]|[1][3-9])))"
 if [[ $INSTALLED_DOCKER_VERSION =~ $MINIMUM_REQUIRED_DOCKER_VERSION_REGEX ]]; then

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -36,6 +36,7 @@ if [ -f "$ozoneInfo" ]; then
 else
     export PROJECT_NAME="ozone"
 fi
+echo "$PROJECT_NAME" > /tmp/project_name.txt
 
 if ! isOzoneRunning "$PROJECT_NAME"; then
     echo "$INFO Starting Ozone project with name: $PROJECT_NAME"
@@ -48,6 +49,7 @@ while isOzoneRunning "$PROJECT_NAME"; do
     suffix=$((suffix + 1))
     export PROJECT_NAME="$PROJECT_NAME-$suffix"
     echo "$INFO Starting a new instance of Ozone with name: $PROJECT_NAME"
+    echo "$PROJECT_NAME" > /tmp/project_name.txt
 done
 
 INSTALLED_DOCKER_VERSION=$(docker version -f "{{.Server.Version}}")

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -29,21 +29,26 @@ if [ "$DEMO" == "true" ]; then
     echo "→ NUMBER_OF_DEMO_PATIENTS=$NUMBER_OF_DEMO_PATIENTS"
 fi
 
-# Check if ozone-info.json exists and read project name
+# Check if ozone-info.json exists and read project name from it
 ozoneInfo="../$DISTRO_PATH/ozone-info.json"
 if [ -f "$ozoneInfo" ]; then
-     projectName=$(grep -o '"name":\s*"[^\"]*"' "$ozoneInfo" | cut -d'"' -f4)
+    export PROJECT_NAME=$(grep -o '"name":\s*"[^\"]*"' "$ozoneInfo" | cut -d'"' -f4)
 else
-    projectName="ozone"
+    export PROJECT_NAME="ozone"
 fi
 
-suffix=0
-while isOzoneRunning "$projectName"; do
-    suffix=$((suffix + 1))
-    projectName="$projectName-$suffix"
-done
+if ! isOzoneRunning "$PROJECT_NAME"; then
+    echo "$INFO Starting Ozone project with name: $PROJECT_NAME"
+fi
 
-echo "$INFO Starting Ozone project with name: $projectName"
+# Check if an instance of Ozone is already running
+suffix=0
+while isOzoneRunning "$PROJECT_NAME"; do
+    echo "$WARN An instance of Ozone is already running with the name: $PROJECT_NAME"
+    suffix=$((suffix + 1))
+    export PROJECT_NAME="$PROJECT_NAME-$suffix"
+    echo "$INFO Starting a new instance of Ozone with name: $PROJECT_NAME"
+done
 
 INSTALLED_DOCKER_VERSION=$(docker version -f "{{.Server.Version}}")
 MINIMUM_REQUIRED_DOCKER_VERSION_REGEX="^((([2-9][1-9]|[3-9][0]|[0-9]{3,}).*)|(20\.([0-9]{3,}|[1-9][1-9]|[2-9][0]).*)|(20\.10\.([0-9]{3,}|[2-9][0-9]|[1][3-9])))"
@@ -56,10 +61,10 @@ if [[ $INSTALLED_DOCKER_VERSION =~ $MINIMUM_REQUIRED_DOCKER_VERSION_REGEX ]]; th
 
     # Pull Ozone Docker images
     echo "$INFO Pulling ${OZONE_LABEL:-Ozone FOSS} images..."
-    docker compose -p $projectName $dockerComposeOzoneCLIOptions pull
+    docker compose -p $PROJECT_NAME $dockerComposeOzoneCLIOptions pull
     
     # Set the Docker Compose command for Ozone
-    dockerComposeOzoneCommand="docker compose -p $projectName $dockerComposeOzoneCLIOptions up -d --build"
+    dockerComposeOzoneCommand="docker compose -p $PROJECT_NAME $dockerComposeOzoneCLIOptions up -d --build"
     echo "$INFO Running ${OZONE_LABEL:-Ozone FOSS}..."
     echo ""
     echo "$dockerComposeOzoneCommand"
@@ -73,7 +78,7 @@ if [[ $INSTALLED_DOCKER_VERSION =~ $MINIMUM_REQUIRED_DOCKER_VERSION_REGEX ]]; th
 
     # Run the Nginx Proxy service, if $TRAEFIK!=true
     if [ "$TRAEFIK" != "true" ]; then
-        dockerComposeProxyCommand="docker compose -p $projectName $dockerComposeProxyCLIOptions up -d --build"
+        dockerComposeProxyCommand="docker compose -p $PROJECT_NAME $dockerComposeProxyCLIOptions up -d --build"
         echo "$INFO Running Nginx proxy service (\$TRAEFIK!=true)..."
         echo ""
         echo "$dockerComposeProxyCommand"
@@ -85,7 +90,7 @@ if [[ $INSTALLED_DOCKER_VERSION =~ $MINIMUM_REQUIRED_DOCKER_VERSION_REGEX ]]; th
 
     # Run the Demo service
     if [ "$DEMO" == "true" ]; then
-        dockerComposeDemoCommand="docker compose -p $projectName $dockerComposeDemoCLIOptions up -d"
+        dockerComposeDemoCommand="docker compose -p $PROJECT_NAME $dockerComposeDemoCLIOptions up -d"
         echo "$INFO Running demo service..."
         echo ""
         echo "$dockerComposeDemoCommand"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -29,6 +29,16 @@ if [ "$DEMO" == "true" ]; then
     echo "→ NUMBER_OF_DEMO_PATIENTS=$NUMBER_OF_DEMO_PATIENTS"
 fi
 
+projectName="ozone"
+suffix=0
+
+while isOzoneRunning "$projectName"; do
+    suffix=$((suffix + 1))
+    projectName="ozone_$suffix"
+done
+
+echo "$INFO Starting Ozone project with name: $projectName"
+
 INSTALLED_DOCKER_VERSION=$(docker version -f "{{.Server.Version}}")
 MINIMUM_REQUIRED_DOCKER_VERSION_REGEX="^((([2-9][1-9]|[3-9][0]|[0-9]{3,}).*)|(20\.([0-9]{3,}|[1-9][1-9]|[2-9][0]).*)|(20\.10\.([0-9]{3,}|[2-9][0-9]|[1][3-9])))"
 if [[ $INSTALLED_DOCKER_VERSION =~ $MINIMUM_REQUIRED_DOCKER_VERSION_REGEX ]]; then
@@ -40,10 +50,10 @@ if [[ $INSTALLED_DOCKER_VERSION =~ $MINIMUM_REQUIRED_DOCKER_VERSION_REGEX ]]; th
 
     # Pull Ozone Docker images
     echo "$INFO Pulling ${OZONE_LABEL:-Ozone FOSS} images..."
-    docker compose -p ozone $dockerComposeOzoneCLIOptions pull
+    docker compose -p $projectName $dockerComposeOzoneCLIOptions pull
     
     # Set the Docker Compose command for Ozone
-    dockerComposeOzoneCommand="docker compose -p ozone $dockerComposeOzoneCLIOptions up -d --build"
+    dockerComposeOzoneCommand="docker compose -p $projectName $dockerComposeOzoneCLIOptions up -d --build"
     echo "$INFO Running ${OZONE_LABEL:-Ozone FOSS}..."
     echo ""
     echo "$dockerComposeOzoneCommand"
@@ -57,7 +67,7 @@ if [[ $INSTALLED_DOCKER_VERSION =~ $MINIMUM_REQUIRED_DOCKER_VERSION_REGEX ]]; th
 
     # Run the Nginx Proxy service, if $TRAEFIK!=true
     if [ "$TRAEFIK" != "true" ]; then
-        dockerComposeProxyCommand="docker compose -p ozone $dockerComposeProxyCLIOptions up -d --build"
+        dockerComposeProxyCommand="docker compose -p $projectName $dockerComposeProxyCLIOptions up -d --build"
         echo "$INFO Running Nginx proxy service (\$TRAEFIK!=true)..."
         echo ""
         echo "$dockerComposeProxyCommand"
@@ -69,7 +79,7 @@ if [[ $INSTALLED_DOCKER_VERSION =~ $MINIMUM_REQUIRED_DOCKER_VERSION_REGEX ]]; th
 
     # Run the Demo service
     if [ "$DEMO" == "true" ]; then
-        dockerComposeDemoCommand="docker compose -p ozone $dockerComposeDemoCLIOptions up -d"
+        dockerComposeDemoCommand="docker compose -p $projectName $dockerComposeDemoCLIOptions up -d"
         echo "$INFO Running demo service..."
         echo ""
         echo "$dockerComposeDemoCommand"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -29,12 +29,18 @@ if [ "$DEMO" == "true" ]; then
     echo "→ NUMBER_OF_DEMO_PATIENTS=$NUMBER_OF_DEMO_PATIENTS"
 fi
 
-projectName="ozone"
-suffix=0
+# Check if ozone-info.json exists and read project name
+ozoneInfo="../$DISTRO_PATH/ozone-info.json"
+if [ -f "$ozoneInfo" ]; then
+     projectName=$(grep -o '"name":\s*"[^\"]*"' "$ozoneInfo" | cut -d'"' -f4)
+else
+    projectName="ozone"
+fi
 
+suffix=0
 while isOzoneRunning "$projectName"; do
     suffix=$((suffix + 1))
-    projectName="ozone_$suffix"
+    projectName="$projectName-$suffix"
 done
 
 echo "$INFO Starting Ozone project with name: $projectName"

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -127,6 +127,16 @@ function setNginxHostnames {
 
 }
 
+function isOzoneRunning {
+    local projectName=$1
+    runningContainers=$(docker ps --filter "name=${projectName}" --format "{{.Names}}")
+    if [ -n "$runningContainers" ]; then
+        return 0  # true
+    else
+        return 1  # false
+    fi
+}
+
 function displayAccessURLsWithCredentials {
     services=()
     is_defined=()

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -2,10 +2,12 @@
 
 export TEXT_BLUE=`tput setaf 4`
 export TEXT_RED=`tput setaf 1`
+export TEXT_YELLOW=`tput setaf 3`
 export BOLD=`tput bold`
 export RESET_FORMATTING=`tput sgr0`
 INFO="$TEXT_BLUE$BOLD[INFO]$RESET_FORMATTING"
 ERROR="$TEXT_RED$BOLD[ERROR]$RESET_FORMATTING"
+WARN="$TEXT_YELLOW$BOLD[WARN]$RESET_FORMATTING"
 
 function setupDirs () {
     # Create the Ozone directory


### PR DESCRIPTION
Issue: https://mekomsolutions.atlassian.net/browse/OZ-627

- Implemented a function to check if the Ozone project is running using Docker.
- Added logic to dynamically assign a numeric suffix to the project name (e.g., ozone_1, ozone_2) if the default project name is already in use.

Todos:
- Still need to take care of exposed ports conflicts, if there are any.