### PR TITLE
OZ-572: Update O3 component URL(s) to use right scheme when Ozone is running locally

### DIFF
--- a/.env
+++ b/.env
@@ -7,6 +7,7 @@
 #
 # Host
 #
+SERVER_SCHEME=https
 HOST_URL=http://172.17.0.1
 TIMEZONE=UTC
 

--- a/docker-compose-odoo.yml
+++ b/docker-compose-odoo.yml
@@ -117,7 +117,7 @@ services:
 
   env-substitution:
     environment:
-      - ODOO_PUBLIC_URL=https://${ODOO_HOSTNAME}
+      - ODOO_PUBLIC_URL=${SERVER_SCHEME}://${ODOO_HOSTNAME}
 
 volumes:
   eip-home-odoo: ~

--- a/docker-compose-openmrs.yml
+++ b/docker-compose-openmrs.yml
@@ -95,7 +95,7 @@ services:
 
   env-substitution:
     environment:
-      - OPENMRS_PUBLIC_URL=https://${O3_HOSTNAME}
+      - OPENMRS_PUBLIC_URL=${SERVER_SCHEME}://${O3_HOSTNAME}
 
 volumes:  
   openmrs-core: ~

--- a/docker-compose-senaite.yml
+++ b/docker-compose-senaite.yml
@@ -81,7 +81,7 @@ services:
     
   env-substitution:
     environment:
-      - SENAITE_PUBLIC_URL=https://${SENAITE_HOSTNAME}
+      - SENAITE_PUBLIC_URL=${SERVER_SCHEME}://${SENAITE_HOSTNAME}
 
 volumes:
   eip-home-senaite: ~

--- a/scripts/ozone-urls-template.csv
+++ b/scripts/ozone-urls-template.csv
@@ -1,6 +1,6 @@
 HIS Component,URL,Username,Password,Service
 -,-,-,-
-OpenMRS 3,${O3_HOSTNAME}/openmrs/spa,admin,Admin123,openmrs
-SENAITE,${SENAITE_HOSTNAME},admin,password,senaite
-Odoo,${ODOO_HOSTNAME},admin,admin,odoo
-ERPNext,${ERPNEXT_HOSTNAME},administrator,password,erpnext
+OpenMRS 3,${SERVER_SCHEME}://${O3_HOSTNAME}/openmrs/spa,admin,Admin123,openmrs
+SENAITE,${SERVER_SCHEME}://${SENAITE_HOSTNAME},admin,password,senaite
+Odoo,${SERVER_SCHEME}://${ODOO_HOSTNAME},admin,admin,odoo
+ERPNext,${SERVER_SCHEME}://${ERPNEXT_HOSTNAME},administrator,password,erpnext

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -57,9 +57,13 @@ MINIMUM_REQUIRED_DOCKER_VERSION_REGEX="^((([2-9][1-9]|[3-9][0]|[0-9]{3,}).*)|(20
 if [[ $INSTALLED_DOCKER_VERSION =~ $MINIMUM_REQUIRED_DOCKER_VERSION_REGEX ]]; then
     if command -v gp version &> /dev/null; then
         export GITPOD_ENV="true"
+        export USE_HTTPS="true"
     else
         export GITPOD_ENV="false"
     fi
+
+    # Export the scheme
+    exportScheme
 
     # Pull Ozone Docker images
     echo "$INFO Pulling ${OZONE_LABEL:-Ozone FOSS} images..."

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -104,6 +104,7 @@ function setTraefikIP {
 function setTraefikHostnames {
     echo "$INFO Exporting Traefik hostnames..."
 
+    export USE_HTTPS="true"
     export O3_HOSTNAME=emr-"${IP_WITH_DASHES}.traefik.me"
     export ODOO_HOSTNAME=erp-"${IP_WITH_DASHES}.traefik.me"
     export SENAITE_HOSTNAME=lims-"${IP_WITH_DASHES}.traefik.me"
@@ -127,6 +128,15 @@ function setNginxHostnames {
     echo "→ SENAITE_HOSTNAME=$SENAITE_HOSTNAME"
     echo "→ ERPNEXT_HOSTNAME=$ERPNEXT_HOSTNAME"
 
+}
+
+function exportScheme() {
+    if [ "$USE_HTTPS" == "true" ]; then
+        export SERVER_SCHEME="https"
+    else
+        export SERVER_SCHEME="http"
+    fi
+    echo "$INFO Scheme set to: $SERVER_SCHEME"
 }
 
 function isOzoneRunning {


### PR DESCRIPTION
Issue: https://mekomsolutions.atlassian.net/jira/software/c/projects/OZ/issues/OZ-572

This PR does;
- Ensure O3 component URLs are set to HTTP for local Ozone instances
- Modify relevant environment variables and docker compose files