### PR TITLE
OZ-627: Update `stop-demo.sh` to use exported project name 

### DIFF
--- a/scripts/stop-demo.sh
+++ b/scripts/stop-demo.sh
@@ -11,15 +11,18 @@ setupDirs
 # Export more environment variables
 exportPaths
 
+# Read PROJECT_NAME from the temporary file
+PROJECT_NAME=$(cat /tmp/project_name.txt)
+
 INSTALLED_DOCKER_VERSION=$(docker version -f "{{.Server.Version}}")
 MINIMUM_REQUIRED_DOCKER_VERSION_REGEX="^((([2-9][1-9]|[3-9][0]|[0-9]{3,}).*)|(20\.([0-9]{3,}|[1-9][1-9]|[2-9][0]).*)|(20\.10\.([0-9]{3,}|[2-9][0-9]|[1][3-9])))"
 if [[ $INSTALLED_DOCKER_VERSION =~ $MINIMUM_REQUIRED_DOCKER_VERSION_REGEX ]]; then
     echo "$INFO Stopping demo service..."
-    docker compose -p ozone $dockerComposeDemoCLIOptions stop
+    docker compose -p $PROJECT_NAME $dockerComposeDemoCLIOptions stop
     echo "$INFO Stopping proxy service..."
-    docker compose -p ozone $dockerComposeProxyCLIOptions stop
+    docker compose -p $PROJECT_NAME $dockerComposeProxyCLIOptions stop
     echo "$INFO Stopping Ozone services..."
-    docker compose -p ozone $dockerComposeOzoneCLIOptions stop
+    docker compose -p $PROJECT_NAME $dockerComposeOzoneCLIOptions stop
 else
     echo "$ERROR Docker versions < 20.10.13 are not supported"
 fi


### PR DESCRIPTION
Updates stop script to use correct container names 