### PR TITLE
fix: Defer DNS resolution of 'fhir-odoo' to runtime to avoid startup errors

### DIFF
--- a/proxy/default.conf.template
+++ b/proxy/default.conf.template
@@ -174,6 +174,7 @@ server {
     location / {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_pass http://fhir-odoo:8080;
+        set $fhirOdd fhir-odoo:8080;
+        proxy_pass http://$fhirOdd;
     }
 }


### PR DESCRIPTION
Nginx proxy is failing to start for us since we don't run oddo.

```
2024/10/16 08:26:52 [emerg] 1#1: host not found in upstream "fhir-odoo" in /etc/nginx/conf.d/default.conf:177
nginx: [emerg] host not found in upstream "fhir-odoo" in /etc/nginx/conf.d/default.conf:177
```

cc @corneliouzbett @enyachoke @michaelbontyes @pirupius 