### PR TITLE
OZ-698: O3 frontend config files served in `configs/` instead of `ozone/`

### DIFF
--- a/.env
+++ b/.env
@@ -25,7 +25,7 @@ OPENMRS_DB_NAME=openmrs
 #
 # OpenMRS frontend
 #
-SPA_CONFIG_URLS=/openmrs/spa/ozone/ozone-frontend-config.json
+SPA_CONFIG_URLS=/openmrs/spa/configs/ozone-frontend-config.json
 SPA_DEFAULT_LOCALE=en
 
 # OpenMRS frontend and backend Docker image tag

--- a/bundled-docker/frontend/Dockerfile
+++ b/bundled-docker/frontend/Dockerfile
@@ -1,6 +1,6 @@
 FROM openmrs/openmrs-reference-application-3-frontend:nightly
 ADD distro/binaries/openmrs/frontend /usr/share/nginx/html
-ADD distro/configs/openmrs/frontend_config /usr/share/nginx/html/ozone
+ADD distro/configs/openmrs/frontend_config /usr/share/nginx/html/configs
 RUN mkdir -p /app
 WORKDIR /app
 COPY bundled-docker/frontend/startup.sh /app

--- a/bundled-docker/frontend/startup.sh
+++ b/bundled-docker/frontend/startup.sh
@@ -1,9 +1,7 @@
 #!/bin/sh
 set -e
-# if [ -f "/usr/share/nginx/html/ozone/ozone-frontend-config.json" ]; then
-#   envsubst < "/usr/share/nginx/html/ozone/ozone-frontend-config.json" | sponge "/usr/share/nginx/html/ozone/ozone-frontend-config.json"
-# fi
-for f in /usr/share/nginx/html/ozone/*.json; do
+
+for f in /usr/share/nginx/html/configs/*.json; do
   echo "processing===> $f";
   envsubst < $f | sponge $f;
 done

--- a/docker-compose-openmrs.yml
+++ b/docker-compose-openmrs.yml
@@ -84,7 +84,7 @@ services:
     restart: unless-stopped
     volumes:
       - "${OPENMRS_FRONTEND_BINARY_PATH}:/usr/share/nginx/html"
-      - "${OPENMRS_FRONTEND_CONFIG_PATH}:/usr/share/nginx/html/ozone"
+      - "${OPENMRS_FRONTEND_CONFIG_PATH}:/usr/share/nginx/html/configs"
 
   mysql:
     environment:


### PR DESCRIPTION
Issue: https://mekomsolutions.atlassian.net/jira/software/c/projects/OZ/issues/OZ-698

This PR updates `/usr/share/nginx/html/ozone` to `/usr/share/nginx/html/configs` and updates references to `SPA_CONFIG_URLS` accordingly.