### PR TITLE
OZ-760: Use 2.6.x-nightly-amazoncorretto-11 OpenMRS image.

### DIFF
--- a/bundled-docker/openmrs/Dockerfile
+++ b/bundled-docker/openmrs/Dockerfile
@@ -1,4 +1,4 @@
-FROM openmrs/openmrs-core:nightly-amazoncorretto-11
+FROM openmrs/openmrs-core:2.6.x-nightly-amazoncorretto-11
 
 # Add modules & configurations for the ozone distribution
 ADD distro/binaries/openmrs/modules /openmrs/distribution/openmrs_modules

--- a/docker-compose-openmrs.yml
+++ b/docker-compose-openmrs.yml
@@ -23,7 +23,7 @@ services:
       timeout: 5s
       retries: 48
       start_period: 120s
-    image: openmrs/openmrs-core:nightly-amazoncorretto-11
+    image: openmrs/openmrs-core:2.6.x-nightly-amazoncorretto-11
     labels:
       traefik.enable: "true"
       traefik.http.routers.openmrs.rule: "Host(`${O3_HOSTNAME}`) && PathPrefix(`/openmrs`)"


### PR DESCRIPTION
Ticket: https://mekomsolutions.atlassian.net/browse/OZ-760