### PR TITLE
OZ-573: Remove ERPNext from bundled docker

### DIFF
--- a/bundled-docker/eip-erpnext-openmrs/Dockerfile
+++ b/bundled-docker/eip-erpnext-openmrs/Dockerfile
@@ -1,2 +1,0 @@
-FROM mekomsolutions/eip-client
-ADD binaries/eip-erpnext-openmrs /eip-client/routes

--- a/bundled-docker/erpnext/Dockerfile
+++ b/bundled-docker/erpnext/Dockerfile
@@ -1,3 +1,0 @@
-FROM frappe/erpnext:v15.12.2
-ADD binaries/erpnext/scripts /opt/erpnext/scripts
-ADD configs/erpnext/initializer_config /opt/erpnext/configs

--- a/bundled-docker/pom.xml
+++ b/bundled-docker/pom.xml
@@ -65,10 +65,8 @@
                                 <resource>
                                     <directory>${project.basedir}/</directory>
                                     <includes>
-                                        <include>eip-erpnext-openmrs/**</include>
                                         <include>eip-odoo-openmrs/**</include>
                                         <include>eip-openmrs-senaite/**</include>
-                                        <include>erpnext/**</include>
                                         <include>frontend/**</include>
                                         <include>mysql/**</include>
                                         <include>odoo/**</include>


### PR DESCRIPTION
Issue: https://mekomsolutions.atlassian.net/browse/OZ-573

This PR removes ERPNext from bundled docker.