### PR TITLE
OZ-331: Add a SENAITE and Keycloak restore profiles

### DIFF
--- a/docker-compose-restore-sso.yml
+++ b/docker-compose-restore-sso.yml
@@ -1,0 +1,7 @@
+services:
+  keycloak:
+    depends_on:
+      restore:
+        condition: service_completed_successfully
+    profiles:
+      - keycloak-restore

--- a/docker-compose-restore.yml
+++ b/docker-compose-restore.yml
@@ -11,6 +11,18 @@ services:
         condition: service_completed_successfully
     profiles:
       - odoo-restore
+  senaite:
+    depends_on:
+      restore:
+        condition: service_completed_successfully
+    profiles:
+      - senaite-restore
+  keycloak:
+    depends_on:
+      restore:
+        condition: service_completed_successfully
+    profiles:
+      - keycloak-restore
   backup:
     depends_on:
       restore:

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -83,6 +83,12 @@ function setDockerComposeCLIOptions () {
         export dockerComposeFilesCLIOptions="$dockerComposeFilesCLIOptions -f ../docker-compose-restore.yml"
     fi
 
+    # Add docker-compose-restore-sso.yml file to prevent Keycloak from being started before the restore
+
+    if [ "$RESTORE" == "true" ] && [ "$ENABLE_SSO" == "true" ]; then
+        export dockerComposeFilesCLIOptions="$dockerComposeFilesCLIOptions -f ../docker-compose-restore-sso.yml"
+    fi
+
     # Set the default env file
     export dockerComposeEnvFilePath="../.env"
 


### PR DESCRIPTION
This PR addresses issues encountered while testing the restore process for Ozone. It adds restore profiles for instances, which include SENAITE with data in PostgreSQL and Keycloak.  

Ticket https://mekomsolutions.atlassian.net/browse/OZ-331