### PR TITLE
OZ-331: Add a validation step for minimum docker compose version

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -46,12 +46,15 @@ fi
 INSTALLED_DOCKER_VERSION=$(docker version -f "{{.Server.Version}}")
 MINIMUM_REQUIRED_DOCKER_VERSION_REGEX="^((([2-9][1-9]|[3-9][0]|[0-9]{3,}).*)|(20\.([0-9]{3,}|[1-9][1-9]|[2-9][0]).*)|(20\.10\.([0-9]{3,}|[2-9][0-9]|[1][3-9])))"
 if [[ $INSTALLED_DOCKER_VERSION =~ $MINIMUM_REQUIRED_DOCKER_VERSION_REGEX ]]; then
-    if command -v gp version &> /dev/null; then
-        export GITPOD_ENV="true"
-        export USE_HTTPS="true"
-    else
-        export GITPOD_ENV="false"
-    fi
+    INSTALLED_DOCKER_COMPOSE_VERSION=$(docker compose version --short 2>/dev/null)
+    MINIMUM_REQUIRED_DOCKER_COMPOSE_VERSION_REGEX="^([2-9]|[1-9][0-9]+)\.*"
+    if [[ $INSTALLED_DOCKER_COMPOSE_VERSION =~ $MINIMUM_REQUIRED_DOCKER_COMPOSE_VERSION_REGEX ]]; then
+        if command -v gp version &> /dev/null; then
+            export GITPOD_ENV="true"
+            export USE_HTTPS="true"
+        else
+            export GITPOD_ENV="false"
+        fi
 
     # Export the scheme
     exportScheme
@@ -96,6 +99,7 @@ if [[ $INSTALLED_DOCKER_VERSION =~ $MINIMUM_REQUIRED_DOCKER_VERSION_REGEX ]]; th
     fi
 
 else
+    echo "$ERROR Docker compose versions < 2.x are not supported"
     echo "$ERROR Docker versions < 20.10.13 are not supported"
 fi
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -98,8 +98,10 @@ if [[ $INSTALLED_DOCKER_VERSION =~ $MINIMUM_REQUIRED_DOCKER_VERSION_REGEX ]]; th
         ($dockerComposeDemoCommand)
     fi
 
+    else
+        echo "$ERROR Docker compose versions < 2.x are not supported"
+    fi
 else
-    echo "$ERROR Docker compose versions < 2.x are not supported"
     echo "$ERROR Docker versions < 20.10.13 are not supported"
 fi
 


### PR DESCRIPTION
Ticket: https://mekomsolutions.atlassian.net/browse/OZ-331?focusedCommentId=46772

This PR adds a validation step for the minimum docker compose version on a host machine.