### PR TITLE
OZ-349: Update SSO access URL display when demo data is disabled

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -96,6 +96,12 @@ if [[ $INSTALLED_DOCKER_VERSION =~ $MINIMUM_REQUIRED_DOCKER_VERSION_REGEX ]]; th
         echo "$dockerComposeDemoCommand"
         echo ""
         ($dockerComposeDemoCommand)
+    else
+        echo "$INFO Skipping running demo service... (\$DEMO!=true)"
+        echo ""
+        echo "$INFO Your $PROJECT_NAME instance is now running without demo data."
+        echo "$INFO To run the demo service, use the following command: ./start-demo.sh or ./start-demo-with-sso.sh for SSO enabled"
+        echo ""
     fi
 
     else

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -276,7 +276,11 @@ function displayAccessURLsWithCredentials {
     echo "$INFO 🔗 Access each ${OZONE_LABEL:-Ozone FOSS} components at the following URL:"
     echo ""
     if [ "$ENABLE_SSO" == "true" ]; then
-        awk -F, 'NR==1 {printf "%-15s %-40s\n", $1, $2} NR>2 && $1 != "Keycloak" {printf "%-15s %-40s\n", $1, $2} END {print "-\nUsername: jdoe\nPassword: password\n-\nIdentity Provider(IDP)\nKeycloak -", $2, " Username:", $3, " Password:", $4}' .urls_2.txt
+        if [ "$DEMO" == "true" ]; then
+            awk -F, 'NR==1 {printf "%-15s %-40s\n", $1, $2} NR>2 && $1 != "Keycloak" {printf "%-15s %-40s\n", $1, $2} END {print "-\nUsername: jdoe\nPassword: password\n-\nIdentity Provider(IDP)\nKeycloak -", $2, " Username:", $3, " Password:", $4}' .urls_2.txt
+        else
+            awk -F, 'NR==1 {printf "%-15s %-40s\n", $1, $2} NR>2 && $1 != "Keycloak" {printf "%-15s %-40s\n", $1, $2} END {print "-\nNOTE: No demo users are available. Please create users manually in Keycloak.\n-\nIdentity Provider(IDP)\nKeycloak -", $2, " Username:", $3, " Password:", $4}' .urls_2.txt
+        fi
     else
         awk -F, 'NR==1 {printf "%-15s %-40s %-15s %-15s\n", $1, $2, $3, $4} NR>2 && $1 != "Keycloak" {printf "%-15s %-40s %-15s %-15s\n", $1, $2, $3, $4}' .urls_2.txt
     fi


### PR DESCRIPTION
Issue: https://mekomsolutions.atlassian.net/browse/OZ-349

This PR does;

- Modify `displayAccessURLsWithCredentials` to handle case where SSO is enabled but demo data is disabled.
- Remove display of non-existent demo user credentials (jdoe/password)