### PR TITLE
OZ-773: Keycloak config loading strategy should default to `IGNORE_EXISTING`

### DIFF
--- a/docker-compose-keycloak.yml
+++ b/docker-compose-keycloak.yml
@@ -30,7 +30,7 @@ services:
        -Dkeycloak.migration.action=import
        -Dkeycloak.migration.provider=dir
        -Dkeycloak.migration.dir=/keycloak-files/realm-config
-       -Dkeycloak.migration.strategy=OVERWRITE_EXISTING"
+       -Dkeycloak.migration.strategy=IGNORE_EXISTING"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://0.0.0.0:8080/health/ready"]
       interval: 15s


### PR DESCRIPTION
As part of testing the Backup & Restore process with no demo data, it appears that loading the KC config at every reboot is creating issues. Basically, if I create a new KC user - which is necessary when running without demo data - then upon next restart, the user will be gone.

As discussed here in Slack: https://mekomsolutions.slack.com/archives/G421UNF5L/p1754639024623649?thread_ts=1754589741.915639&cid=G421UNF5L

> I’d say that there is 3 things that users would do:
    (1) Evaluation
    (2) Development/config/implement
    (3) Run in prod.
    
> For the users who would do the (1), then it’s possible they are trying Ozone one day, stopping it, starting it again the next day to resume their testing etc...
In that sense, having the KC users to stick is probably preferable.

> For (2), I can see that those users, should they need to configure KC, would need to have the configs applied upon restart. Though it’s only if they are configuring KC.

> For (3), definitely must not apply the KC configs upon restart

Now I don't know if that's the cause of the issues with the restore process. But anyway that setting should be fixed.