### PR TITLE
HIS-28: Add a Dockerfile to bundle grafana-agent

### DIFF
--- a/bundled-docker/grafana-agent/Dockerfile
+++ b/bundled-docker/grafana-agent/Dockerfile
@@ -1,0 +1,2 @@
+FROM grafana/agent:latest
+ADD logging/agent-config.yaml /etc/grafana-agent/config.yaml

--- a/bundled-docker/pom.xml
+++ b/bundled-docker/pom.xml
@@ -75,6 +75,7 @@
                                         <include>proxy/**</include>
                                         <include>senaite/**</include>
                                         <include>keycloak/**</include>
+                                        <include>grafana-agent/**</include>
                                         <include>scripts/**</include>
                                     </includes>
                                 </resource>

--- a/docker-compose-logging-agent.yml
+++ b/docker-compose-logging-agent.yml
@@ -1,6 +1,6 @@
 services:
   grafana-agent:
-    image: mekomsolutions/maven-parent-grafana-agent
+    image: grafana/agent:latest
     volumes:
       - /var/lib/docker/containers:/var/lib/docker/containers:ro
       - /var/log:/var/log:ro

--- a/docker-compose-logging-agent.yml
+++ b/docker-compose-logging-agent.yml
@@ -5,7 +5,7 @@ services:
       - /var/lib/docker/containers:/var/lib/docker/containers:ro
       - /var/log:/var/log:ro
       - /etc/machine-id:/etc/machine-id:ro
-      # - ./logging/agent-config.yaml:/etc/grafana-agent/config.yaml:ro
+      - ./logging/agent-config.yaml:/etc/grafana-agent/config.yaml:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
     environment:
       - LOKI_URL=${LOKI_URL:-http://host.docker.internal:3100/loki/api/v1/push}

--- a/docker-compose-logging-agent.yml
+++ b/docker-compose-logging-agent.yml
@@ -1,11 +1,11 @@
 services:
   grafana-agent:
-    image: grafana/agent:latest
+    image: mekomsolutions/maven-parent-grafana-agent
     volumes:
       - /var/lib/docker/containers:/var/lib/docker/containers:ro
       - /var/log:/var/log:ro
       - /etc/machine-id:/etc/machine-id:ro
-      - ./logging/agent-config.yaml:/etc/grafana-agent/config.yaml:ro
+      # - ./logging/agent-config.yaml:/etc/grafana-agent/config.yaml:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
     environment:
       - LOKI_URL=${LOKI_URL:-http://host.docker.internal:3100/loki/api/v1/push}

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
                   <includes>
                     <include>proxy/</include>
                     <include>openmrs/</include>
+                    <include>logging/</include>
                     <include>*docker-compose*</include>
                     <include>*env</include>
                     <include>scripts/</include>


### PR DESCRIPTION
This PR adds a Dockerfile to allow bundling of config for the Grafana Agent.