### PR TITLE
HIS-28: Remove the unsupported --log-console-json-format and revert keycloak.migration.strategy to IGNORE_EXISTING

### DIFF
--- a/docker-compose-keycloak.yml
+++ b/docker-compose-keycloak.yml
@@ -30,9 +30,8 @@ services:
        -Dkeycloak.migration.action=import
        -Dkeycloak.migration.provider=dir
        -Dkeycloak.migration.dir=/keycloak-files/realm-config
-       -Dkeycloak.migration.strategy=OVERWRITE_EXISTING
-       --log-console-output=json
-       --log-console-json-format=ecs"
+       -Dkeycloak.migration.strategy=IGNORE_EXISTING
+       --log-console-output=json"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://0.0.0.0:8080/health/ready"]
       interval: 15s


### PR DESCRIPTION
The PR remove the unsupported --log-console-json-format,reverts keycloak.migration.strategy to IGNORE_EXISTING