### PR TITLE
HIS: Fix 502 error when Odoo or Superset are accessed from OpenMRS for Distro HIS

### DIFF
--- a/bundled-docker/proxy/default.conf.template
+++ b/bundled-docker/proxy/default.conf.template
@@ -166,5 +166,8 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         set $keycloak keycloak:8080;
         proxy_pass http://$keycloak;
+        proxy_buffer_size 128k;
+        proxy_buffers 4 256k;
+        proxy_busy_buffers_size 256k;
     }
 }

--- a/bundled-docker/proxy/default.conf.template
+++ b/bundled-docker/proxy/default.conf.template
@@ -162,7 +162,7 @@ server {
     listen 8084;
     location / {
         proxy_set_header Host $http_host;
-        proxy_set_header X-Forward-Proto http;
+        proxy_set_header X-Forwarded-Proto http;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         set $keycloak keycloak:8080;
         proxy_pass http://$keycloak;

--- a/proxy/default.conf.template
+++ b/proxy/default.conf.template
@@ -330,7 +330,7 @@ server {
     listen 8084;
     location / {
         proxy_set_header Host $http_host;
-        proxy_set_header X-Forward-Proto http;
+        proxy_set_header X-Forwarded-Proto http;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         set $keycloak keycloak:8080;
         proxy_pass http://$keycloak;


### PR DESCRIPTION
This increases the buffer size for NGINX, which should hopefully resolve the 502 error when trying to access Superset and Odoo using the Links in the EMR.