### PR TITLE
Update Keycloak Docker image to use bitnami legacy version

### DIFF
--- a/bundled-docker/keycloak/Dockerfile
+++ b/bundled-docker/keycloak/Dockerfile
@@ -1,3 +1,3 @@
-FROM docker.io/bitnami/keycloak:22.0.5
+FROM docker.io/bitnamilegacy/keycloak:22.0.5
 ADD configs/keycloak/realms /keycloak-files/realm-config
 ADD configs/keycloak/themes/carbon /opt/bitnami/keycloak/themes/carbon

--- a/docker-compose-keycloak.yml
+++ b/docker-compose-keycloak.yml
@@ -1,7 +1,7 @@
 services:
 
   keycloak:
-    image: docker.io/bitnami/keycloak:22.0.5
+    image: docker.io/bitnamilegacy/keycloak:22.0.5
     restart: unless-stopped
     volumes:
       - ${KEYCLOAK_CONFIG_PATH}/realms:/keycloak-files/realm-config


### PR DESCRIPTION
Issue: https://github.com/bitnami/containers/issues/83267

docker.io/bitnami/keycloak:22.0.5 is no longer available.