### PR TITLE
OZ-960: Fix typos in `start.sh` script.

### DIFF
--- a/scripts/ozone-urls-template.csv
+++ b/scripts/ozone-urls-template.csv
@@ -1,5 +1,5 @@
-HIS Component,URL,Username,Password,Service
--,-,-,-
+HIS App,URL,Username,Password,Service
+-,-,-,-,
 OpenMRS 3,${SERVER_SCHEME}://${O3_HOSTNAME}/openmrs/spa,admin,Admin123,openmrs
 Bahmni EMR,${SERVER_SCHEME}://${BAHMNI_EMR_HOSTNAME}/bahmni/home,superman,Admin123,bahmniemr
 SENAITE,${SERVER_SCHEME}://${SENAITE_HOSTNAME},admin,password,senaite

--- a/scripts/ozone-urls-template.csv
+++ b/scripts/ozone-urls-template.csv
@@ -1,5 +1,5 @@
 HIS App,URL,Username,Password,Service
--,-,-,-,
+-,-,-,-
 OpenMRS 3,${SERVER_SCHEME}://${O3_HOSTNAME}/openmrs/spa,admin,Admin123,openmrs
 Bahmni EMR,${SERVER_SCHEME}://${BAHMNI_EMR_HOSTNAME}/bahmni/home,superman,Admin123,bahmniemr
 SENAITE,${SERVER_SCHEME}://${SENAITE_HOSTNAME},admin,password,senaite

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -277,9 +277,9 @@ function displayAccessURLsWithCredentials {
     echo ""
     if [ "$ENABLE_SSO" == "true" ]; then
         if [ "$DEMO" == "true" ]; then
-            awk -F, 'NR==1 {printf "%-15s %-40s\n", $1, $2} NR>2 && $1 != "Keycloak" {printf "%-15s %-40s\n", $1, $2} END {print "-\nUsername: jdoe\nPassword: password\n-\nIdentity Provider(Idp)\nKeycloak -", $2, " Username:", $3, " Password:", $4}' .urls_2.txt
+            awk -F, 'NR==1 {printf "%-15s %-40s\n", $1, $2} NR>2 && $1 != "Keycloak" {printf "%-15s %-40s\n", $1, $2} END {print "-\nUsername: jdoe\nPassword: password\n-\nIdentity Provider(IdP)\nKeycloak -", $2, " Username:", $3, " Password:", $4}' .urls_2.txt
         else
-            awk -F, 'NR==1 {printf "%-15s %-40s\n", $1, $2} NR>2 && $1 != "Keycloak" {printf "%-15s %-40s\n", $1, $2} END {print "-\n⚠️  No demo users are available. Please create users manually in Keycloak.\n-\nIdentity Provider(Idp)\nKeycloak -", $2, " Username:", $3, " Password:", $4}' .urls_2.txt
+            awk -F, 'NR==1 {printf "%-15s %-40s\n", $1, $2} NR>2 && $1 != "Keycloak" {printf "%-15s %-40s\n", $1, $2} END {print "-\n⚠️  No demo users are available. Please create users manually in Keycloak.\n-\nIdentity Provider(IdP)\nKeycloak -", $2, " Username:", $3, " Password:", $4}' .urls_2.txt
         fi
     else
         awk -F, 'NR==1 {printf "%-15s %-40s %-15s %-15s\n", $1, $2, $3, $4} NR>2 && $1 != "Keycloak" {printf "%-15s %-40s %-15s %-15s\n", $1, $2, $3, $4}' .urls_2.txt

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -247,7 +247,7 @@ function extractServicesFromComposeFiles() {
 }
 
 function displayAccessURLsWithCredentials {
-    echo "HIS Component,URL,Username,Password" > .urls_1.txt
+    echo "HIS App,URL,Username,Password" > .urls_1.txt
     echo "-,-,-,-" >> .urls_1.txt
 
     definedServices=()
@@ -273,13 +273,13 @@ function displayAccessURLsWithCredentials {
     envsubst < .urls_1.txt > .urls_2.txt
 
     echo ""
-    echo "$INFO 🔗 Access each ${OZONE_LABEL:-Ozone FOSS} components at the following URL:"
+    echo "$INFO 🔗 Access each ${OZONE_LABEL:-Ozone FOSS} app at the following URL:"
     echo ""
     if [ "$ENABLE_SSO" == "true" ]; then
         if [ "$DEMO" == "true" ]; then
-            awk -F, 'NR==1 {printf "%-15s %-40s\n", $1, $2} NR>2 && $1 != "Keycloak" {printf "%-15s %-40s\n", $1, $2} END {print "-\nUsername: jdoe\nPassword: password\n-\nIdentity Provider(IDP)\nKeycloak -", $2, " Username:", $3, " Password:", $4}' .urls_2.txt
+            awk -F, 'NR==1 {printf "%-15s %-40s\n", $1, $2} NR>2 && $1 != "Keycloak" {printf "%-15s %-40s\n", $1, $2} END {print "-\nUsername: jdoe\nPassword: password\n-\nIdentity Provider(Idp)\nKeycloak -", $2, " Username:", $3, " Password:", $4}' .urls_2.txt
         else
-            awk -F, 'NR==1 {printf "%-15s %-40s\n", $1, $2} NR>2 && $1 != "Keycloak" {printf "%-15s %-40s\n", $1, $2} END {print "-\n⚠️  No demo users are available. Please create users manually in Keycloak.\n-\nIdentity Provider(IDP)\nKeycloak -", $2, " Username:", $3, " Password:", $4}' .urls_2.txt
+            awk -F, 'NR==1 {printf "%-15s %-40s\n", $1, $2} NR>2 && $1 != "Keycloak" {printf "%-15s %-40s\n", $1, $2} END {print "-\n⚠️  No demo users are available. Please create users manually in Keycloak.\n-\nIdentity Provider(Idp)\nKeycloak -", $2, " Username:", $3, " Password:", $4}' .urls_2.txt
         fi
     else
         awk -F, 'NR==1 {printf "%-15s %-40s %-15s %-15s\n", $1, $2, $3, $4} NR>2 && $1 != "Keycloak" {printf "%-15s %-40s %-15s %-15s\n", $1, $2, $3, $4}' .urls_2.txt


### PR DESCRIPTION
Ticket: https://mekomsolutions.atlassian.net/browse/OZ-960