### PR TITLE
INFRA-494: Split Loki and Grafana to allow independent deployment

### DIFF
--- a/docker-compose-logging-grafana.yaml
+++ b/docker-compose-logging-grafana.yaml
@@ -1,15 +1,4 @@
 services:
-  loki:
-    image: grafana/loki:3.0.0
-    container_name: loki
-    ports:
-      - 3100:3100
-    command: -config.file=/etc/loki/loki.yaml
-    volumes:     
-     - ./logging/loki-config.yaml:/etc/loki/loki.yaml
-     - ${LOKI_DATA_DIR:-loki-data}:/loki
-    networks:
-      logging:
   grafana:
     image: grafana/grafana:10.2.3
     ports:
@@ -32,7 +21,6 @@ services:
 
 volumes:
   grafana-data:
-  loki-data:
 
 networks:
   logging:

--- a/docker-compose-logging-loki.yaml
+++ b/docker-compose-logging-loki.yaml
@@ -1,0 +1,20 @@
+services:
+  loki:
+    image: grafana/loki:3.0.0
+    container_name: loki
+    ports:
+      - 3100:3100
+    command: -config.file=/etc/loki/loki.yaml
+    volumes:     
+     - ./logging/loki-config.yaml:/etc/loki/loki.yaml
+     - ${LOKI_DATA_DIR:-loki-data}:/loki
+    networks:
+      logging:
+
+volumes:
+  loki-data:
+
+networks:
+  logging:
+  web:
+   external: true


### PR DESCRIPTION
This is ground work for setting up Logging for Ozone.